### PR TITLE
Make include of vars file optional

### DIFF
--- a/tasks/main.yml
+++ b/tasks/main.yml
@@ -9,9 +9,18 @@
 - name: Configure the MySQL server
   include_tasks: "config_mysql{{ mysql_installrepo_version }}.yml"
 
+# NOTE: if you do not use a project vars file, the database and user variables
+# must be set in some other way, there are multiple options for doing this
+# but you'll need to use them, and they may not be as secure as using a
+# project vars file
+
+- name: Determine if optional project vars file exists
+  local_action: stat path="{{ project_name }}_{{ env_name }}.yml"
+  register: project_vars_file
+
 - name: Set Database and User Variables
   include_vars: "{{ project_name }}_{{ env_name }}.yml"
-  when: (project_name is defined) and (env_name is defined)
+  when: project_vars_file.stat.exists
   no_log: True
 
 - name: Create MySQL Databases


### PR DESCRIPTION
first attempt to register the project vars file,
then only attempt to include it if the file exists