### PR TITLE
Remove variables/tasks that allow for proj specific vars

### DIFF
--- a/defaults/main.yml
+++ b/defaults/main.yml
@@ -1,9 +1,5 @@
 ---
 
-# These should be included in the play file or inventroy file.
-# project_name: ""
-# env_name: ""
-
 mysql_defaultrepo_version: "80"
 
 mysql_yumrepo_rpm: "https://dev.mysql.com/get/mysql{{ mysql_defaultrepo_version }}-community-release-el7-1.noarch.rpm"

--- a/tasks/main.yml
+++ b/tasks/main.yml
@@ -9,21 +9,6 @@
 - name: Configure the MySQL server
   include_tasks: "config_mysql{{ mysql_installrepo_version }}.yml"
 
-# This allows for making the {{ project_name }}_{{ env_name }}.yml vars file optional.
-# If this vars file is _not_ included in the role, the variables should be defined
-# elsehwere - e.g. in the playbook file
-- name: Determine if the project-specific vars file exists
-  local_action:
-    module: stat
-    path: "{{ role_path }}/vars/{{ project_name }}_{{ env_name }}.yml"
-  become: False
-  register: project_vars_file
-
-- name: Set Database and User Variables
-  include_vars: "{{ project_name }}_{{ env_name }}.yml"
-  when: project_vars_file.stat.exists
-  no_log: True
-
 - name: Create MySQL Databases
   include_tasks: create_mysql_databases.yml
   when: mysql_databases is defined


### PR DESCRIPTION
Remove the ability for the role to load in variables defined as project specific vars in the roles vars sub directory. Moving forward, these variables should be defined in host_vars/group_vars. 